### PR TITLE
[Feature] 상품 태그로 상품을 조회하는 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	// QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/teamA/hicardi/domain/faq/controller/FaqController.java
+++ b/src/main/java/com/teamA/hicardi/domain/faq/controller/FaqController.java
@@ -52,7 +52,7 @@ public class FaqController {
         return PageResponseDto.of(response);
     }
 
-    @Operation(summary = "FAQ 카테고리(USE, DELIVERY, DEVICE, ETC)별 조회", description = "FAQ를 카테고리(USE, DELIVERY, DEVICE, ETC)별로 조회합니다.",
+    @Operation(summary = "FAQ 카테고리(사용법, 기기, 배송, 기타)별 조회", description = "FAQ를 카테고리(사용법, 기기, 배송, 기타)별로 조회합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "FAQ 카테고리별 조회 성공")
                     , @ApiResponse(responseCode = "400", description = "1. 카테고리를 입력해야 합니다. \t\n 2. 잘못된 카테고리입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/com/teamA/hicardi/domain/faq/entity/Category.java
+++ b/src/main/java/com/teamA/hicardi/domain/faq/entity/Category.java
@@ -16,7 +16,7 @@ public enum Category {
     @JsonCreator
     public static Category create(String requestValue) {
         return Stream.of(values())
-                .filter(v -> v.toString().equalsIgnoreCase(requestValue))
+                .filter(v -> v.desc.equalsIgnoreCase(requestValue))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CATEGORY));
     }

--- a/src/main/java/com/teamA/hicardi/domain/item/controller/ItemController.java
+++ b/src/main/java/com/teamA/hicardi/domain/item/controller/ItemController.java
@@ -14,10 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -47,5 +44,16 @@ public class ItemController {
     public ResponseEntity<ItemGetResponseDto> getItem(@PathVariable Long itemId){
         ItemGetResponseDto itemGetResponseDto = itemService.getItem(itemId);
         return ResponseEntity.ok(itemGetResponseDto);
+    }
+
+    @Operation(summary = "상품 태그로 상품 조회", description = "상품 태그로 상품을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "상품 태그로 상품 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 태그입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/tags")
+    public ResponseEntity<PageResponseDto> searchTagItems(@RequestParam String search, Pageable pageable) {
+        Page<ItemsGetResponseDto> response = itemService.searchTagItems(search, pageable);
+        return PageResponseDto.of(response);
     }
 }

--- a/src/main/java/com/teamA/hicardi/domain/item/entity/Tag.java
+++ b/src/main/java/com/teamA/hicardi/domain/item/entity/Tag.java
@@ -26,7 +26,7 @@ public enum Tag {
     @JsonCreator
     public static Tag create(String requestValue) {
         return Stream.of(values())
-                .filter(v -> v.toString().equalsIgnoreCase(requestValue))
+                .filter(v -> v.desc.equalsIgnoreCase(requestValue))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_TAG));
     }

--- a/src/main/java/com/teamA/hicardi/domain/item/repository/ItemTagRepository.java
+++ b/src/main/java/com/teamA/hicardi/domain/item/repository/ItemTagRepository.java
@@ -2,11 +2,20 @@ package com.teamA.hicardi.domain.item.repository;
 
 import com.teamA.hicardi.domain.item.entity.Item;
 import com.teamA.hicardi.domain.item.entity.ItemTag;
+import com.teamA.hicardi.domain.item.entity.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ItemTagRepository extends JpaRepository<ItemTag, Long> {
 
     List<ItemTag> findAllByItem(Item item);
+
+    @Query("select distinct i.item from ItemTag i " +
+            " where i.tag = :tag")
+    Page<Item> findAllByTag(@Param("tag") Tag tag, Pageable pageable);
 }

--- a/src/main/java/com/teamA/hicardi/domain/item/service/ItemService.java
+++ b/src/main/java/com/teamA/hicardi/domain/item/service/ItemService.java
@@ -5,6 +5,7 @@ import com.teamA.hicardi.domain.item.dto.response.ItemsGetResponseDto;
 import com.teamA.hicardi.domain.item.entity.Item;
 import com.teamA.hicardi.domain.item.entity.ItemImage;
 import com.teamA.hicardi.domain.item.entity.ItemTag;
+import com.teamA.hicardi.domain.item.entity.Tag;
 import com.teamA.hicardi.domain.item.repository.ItemImageRepository;
 import com.teamA.hicardi.domain.item.repository.ItemRepository;
 import com.teamA.hicardi.domain.item.repository.ItemTagRepository;
@@ -47,5 +48,12 @@ public class ItemService {
 			.toList();
 
 		return ItemGetResponseDto.from(item, images, itemTags);
+	}
+
+	public Page<ItemsGetResponseDto> searchTagItems(String search, Pageable pageable) {
+		Tag tag = Tag.create(search);
+		Page<Item> items = itemTagRepository.findAllByTag(tag, pageable);
+		Page<ItemsGetResponseDto> response = items.map(i -> ItemsGetResponseDto.from(i, itemTagRepository.findAllByItem(i)));
+		return response;
 	}
 }

--- a/src/test/java/com/teamA/hicardi/domain/faq/controller/FaqControllerTest.java
+++ b/src/test/java/com/teamA/hicardi/domain/faq/controller/FaqControllerTest.java
@@ -102,7 +102,7 @@ class FaqControllerTest {
         given(faqService.getCategoryFaqs(anyString(), any())).willReturn(response);
         ResultActions result = mockMvc.perform(
                 get("/faqs/category")
-                        .param("search", "USE")
+                        .param("search", "사용법")
         );
 
         //then

--- a/src/test/java/com/teamA/hicardi/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/teamA/hicardi/domain/item/controller/ItemControllerTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -84,5 +85,26 @@ class ItemControllerTest {
         result.andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print());
         verify(itemService, times(1)).getItem(any());
+    }
+
+    @Test
+    void 상품_태그로_상품_조회() throws Exception {
+        //given
+        PageRequest pageable = PageRequest.of(0, 5);
+        List<ItemsGetResponseDto> dtos = new ArrayList<>();
+        dtos.add(new ItemsGetResponseDto(1L, "하이카디플러스", "하이카디", Collections.singletonList("SmartPatch,DeviceBody"), "1.svg", 10000, 100, "SELL"));
+        dtos.add(new ItemsGetResponseDto(1L, "하이카디플러스2", "하이카디2", Collections.singletonList("SmartPatch,DeviceBody"), "2.svg", 20000, 200, "SELL"));
+        Page<ItemsGetResponseDto> response = new PageImpl<>(dtos, pageable, 2);
+
+        //when
+        given(itemService.searchTagItems(anyString(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/items/tags")
+                        .param("search", "Smart Patch")
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(itemService, times(1)).searchTagItems(anyString(), any());
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #59 

## 📝 작업 내용
- QueryDsl 의존성 추가
- 상품 태그로 상품을 조회하는 로직 구현
- Controller 테스트 코드 추가
- FAQ 조회 시 description으로 검색하도록 변경

## 💬 리뷰 요구 사항
태그로 상품을 조회한 후, 해당 태그를 가진 상품의 태그를 찾아 Dto로 반환하는 과정에서 리팩토링 필요함
